### PR TITLE
Added PATH var fix for CentOS and alike

### DIFF
--- a/clab/ixia-c-te-frr/README.md
+++ b/clab/ixia-c-te-frr/README.md
@@ -25,6 +25,18 @@ In this setup, we demonstrate how to deploy Ixia-c Traffic Engine nodes in Conta
     sudo chmod +x /usr/local/bin/otgen
     ```
 
+* Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+
+    ```Shell
+    cmd=otgen
+    dir=/usr/local/bin
+    if ! command -v ${cmd} &> /dev/null && [ -x ${dir}/${cmd} ]; then
+      echo "${cmd} exists in ${dir} but not in the PATH, updating PATH to:"
+      PATH="/usr/local/bin:${PATH}"
+      echo $PATH
+    fi
+    ```
+
 ## Clone the repository
 
 1. Clone this repository to the Linux host where you want to run the lab. Do this only once.

--- a/clab/ixia-c-te-frr/README.md
+++ b/clab/ixia-c-te-frr/README.md
@@ -25,7 +25,7 @@ In this setup, we demonstrate how to deploy Ixia-c Traffic Engine nodes in Conta
     sudo chmod +x /usr/local/bin/otgen
     ```
 
-* Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+* Make sure `/usr/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
 
     ```Shell
     cmd=otgen

--- a/docker-compose/b2b-3pair/README.md
+++ b/docker-compose/b2b-3pair/README.md
@@ -27,7 +27,7 @@ sudo mv otgen /usr/local/bin/otgen
 sudo chmod +x /usr/local/bin/otgen
 ```
 
-3. Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+3. Make sure `/usr/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
 
 ```Shell
 cmd=docker-compose

--- a/docker-compose/b2b-3pair/README.md
+++ b/docker-compose/b2b-3pair/README.md
@@ -27,7 +27,19 @@ sudo mv otgen /usr/local/bin/otgen
 sudo chmod +x /usr/local/bin/otgen
 ```
 
-3. Clone this repository
+3. Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+
+```Shell
+cmd=docker-compose
+dir=/usr/local/bin
+if ! command -v ${cmd} &> /dev/null && [ -x ${dir}/${cmd} ]; then
+  echo "${cmd} exists in ${dir} but not in the PATH, updating PATH to:"
+  PATH="/usr/local/bin:${PATH}"
+  echo $PATH
+fi
+```
+
+4. Clone this repository
 
 ```Shell
 git clone https://github.com/open-traffic-generator/otg-examples.git

--- a/docker-compose/b2b/README.md
+++ b/docker-compose/b2b/README.md
@@ -27,6 +27,18 @@ sudo mv otgen /usr/local/bin/otgen
 sudo chmod +x /usr/local/bin/otgen
 ```
 
+3. Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+
+```Shell
+cmd=docker-compose
+dir=/usr/local/bin
+if ! command -v ${cmd} &> /dev/null && [ -x ${dir}/${cmd} ]; then
+  echo "${cmd} exists in ${dir} but not in the PATH, updating PATH to:"
+  PATH="/usr/local/bin:${PATH}"
+  echo $PATH
+fi
+```
+
 ## Deploy Ixia-c lab
 
 1. Create veth pair `veth0 - veth1`

--- a/docker-compose/b2b/README.md
+++ b/docker-compose/b2b/README.md
@@ -27,7 +27,7 @@ sudo mv otgen /usr/local/bin/otgen
 sudo chmod +x /usr/local/bin/otgen
 ```
 
-3. Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+3. Make sure `/usr/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
 
 ```Shell
 cmd=docker-compose

--- a/docker-compose/cpdp-b2b/README.md
+++ b/docker-compose/cpdp-b2b/README.md
@@ -21,7 +21,19 @@ sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-2. Clone this repository
+2. Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+
+```Shell
+cmd=docker-compose
+dir=/usr/local/bin
+if ! command -v ${cmd} &> /dev/null && [ -x ${dir}/${cmd} ]; then
+  echo "${cmd} exists in ${dir} but not in the PATH, updating PATH to:"
+  PATH="/usr/local/bin:${PATH}"
+  echo $PATH
+fi
+```
+
+1. Clone this repository
 
 ```Shell
 git clone https://github.com/open-traffic-generator/otg-examples.git

--- a/docker-compose/cpdp-b2b/README.md
+++ b/docker-compose/cpdp-b2b/README.md
@@ -21,7 +21,7 @@ sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-
 sudo chmod +x /usr/local/bin/docker-compose
 ```
 
-2. Make sure `/use/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
+2. Make sure `/usr/local/bin` is in your `$PATH` variable (by default this is not the case on CentOS 7)
 
 ```Shell
 cmd=docker-compose


### PR DESCRIPTION
By default CentOS doesn't have `/usr/local/bin` in the path and that was breaking some examples.