### PR TITLE
rolled back running test in gosnappi container

### DIFF
--- a/clab/rtbh/Makefile
+++ b/clab/rtbh/Makefile
@@ -53,4 +53,5 @@ remove-lab:
 run: gosnappi-run
 
 gosnappi-run:
-	sudo docker exec -t clab-rtbh-gosnappi bash -c "go test -dstMac=$$(sudo docker exec clab-rtbh-pe-router vtysh -c  'sh interface eth2 | include HWaddr' | awk '{print $$2}')"
+	#sudo docker exec -t clab-rtbh-gosnappi bash -c "go test -dstMac=$$(sudo docker exec clab-rtbh-pe-router vtysh -c  'sh interface eth2 | include HWaddr' | awk '{print $$2}')"
+	go test -dstMac=$$(sudo docker exec clab-rtbh-pe-router vtysh -c  'sh interface eth2 | include HWaddr' | awk '{print $$2}')


### PR DESCRIPTION
too low performance if run inside a container, doesn't get to ddos threshold