### PR TITLE
Migrated all examples to use ghrc.com container registry

### DIFF
--- a/clab/ixia-c-te-frr/topo.clab.yml
+++ b/clab/ixia-c-te-frr/topo.clab.yml
@@ -3,13 +3,13 @@ topology:
   nodes:
     ixc:
       kind: linux
-      image: ixiacom/ixia-c-controller:0.0.1-3027
+      image: ghcr.io/open-traffic-generator/ixia-c-controller:0.0.1-3182
       cmd: --accept-eula --http-port 443
       ports:
         - 443:443
     te1:
       kind: linux
-      image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
       exec:
         - ip address add 192.0.2.1/30 dev eth1
         - ip route add 192.0.2.4/30 via 192.0.2.2
@@ -28,7 +28,7 @@ topology:
       - ./frr/vtysh.conf:/etc/frr/vtysh.conf
     te2:
       kind: linux
-      image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
       exec:
         - ip address add 192.0.2.5/30 dev eth1
         - ip route add 192.0.2.0/30 via 192.0.2.6

--- a/clab/ixia-c-te-frr/topo.graphite.yml
+++ b/clab/ixia-c-te-frr/topo.graphite.yml
@@ -3,7 +3,7 @@ topology:
   nodes:
     ixc:
       kind: linux
-      image: ixiacom/ixia-c-controller:0.0.1-3027
+      image: ghcr.io/open-traffic-generator/ixia-c-controller:0.0.1-3182
       cmd: --accept-eula --http-port 443
       ports:
         - 443:443
@@ -11,7 +11,7 @@ topology:
         graph-hide: yes
     te1:
       kind: linux
-      image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
       exec:
         - ip address add 192.0.2.1/30 dev eth1
         - ip route add 192.0.2.4/30 via 192.0.2.2
@@ -32,7 +32,7 @@ topology:
       - ./frr/vtysh.conf:/etc/frr/vtysh.conf
     te2:
       kind: linux
-      image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
       exec:
         - ip address add 192.0.2.5/30 dev eth1
         - ip route add 192.0.2.0/30 via 192.0.2.6

--- a/docker-compose/b2b/ixia-c-b2b.yml
+++ b/docker-compose/b2b/ixia-c-b2b.yml
@@ -1,6 +1,6 @@
 services:
   controller:
-    image: ghcr.io/open-traffic-generator/ixia-c-controller:0.0.1-3295
+    image: ghcr.io/open-traffic-generator/ixia-c-controller:0.0.1-3182
     command: --accept-eula --http-port 443
     network_mode: "host"
     restart: always

--- a/docker-compose/b2b/ixia-c-b2b.yml
+++ b/docker-compose/b2b/ixia-c-b2b.yml
@@ -1,11 +1,11 @@
 services:
   controller:
-    image: ixiacom/ixia-c-controller:0.0.1-3002
+    image: ghcr.io/open-traffic-generator/ixia-c-controller:0.0.1-3295
     command: --accept-eula --http-port 443
     network_mode: "host"
     restart: always
   traffic_engine_1:
-    image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
     network_mode: "host"
     restart: always
     privileged: true
@@ -14,7 +14,7 @@ services:
     - ARG_IFACE_LIST=virtual@af_packet,veth0
     - OPT_NO_HUGEPAGES=Yes
   traffic_engine_2:
-    image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
     network_mode: "host"
     restart: always
     privileged: true

--- a/docker-compose/cpdp-b2b/cpdp-b2b.yml
+++ b/docker-compose/cpdp-b2b/cpdp-b2b.yml
@@ -1,11 +1,11 @@
 services:
   controller:
-    image: ghcr.io/open-traffic-generator/licensed/ixia-c-controller:0.0.1-3002
+    image: ghcr.io/open-traffic-generator/licensed/ixia-c-controller:0.0.1-3182
     command: --accept-eula --http-port 443
     network_mode: "host"
     restart: always
   traffic_engine_1:
-    image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
     restart: always
     privileged: true
     ports:
@@ -18,7 +18,7 @@ services:
     - OPT_NO_PINNING=Yes
     - WAIT_FOR_IFACE=Yes
   traffic_engine_2:
-    image: ixiacom/ixia-c-traffic-engine:1.4.1.29
+    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.9
     restart: always
     privileged: true
     ports:
@@ -31,14 +31,14 @@ services:
     - OPT_NO_PINNING=Yes
     - WAIT_FOR_IFACE=Yes
   protocol_engine_1:
-    image: ghcr.io/open-traffic-generator/licensed/ixia-c-protocol-engine:1.00.0.205
+    image: ghcr.io/open-traffic-generator/licensed/ixia-c-protocol-engine:1.00.0.217
     restart: always
     privileged: true
     network_mode: service:traffic_engine_1
     environment:
     - INTF_LIST=veth0
   protocol_engine_2:
-    image: ghcr.io/open-traffic-generator/licensed/ixia-c-protocol-engine:1.00.0.205
+    image: ghcr.io/open-traffic-generator/licensed/ixia-c-protocol-engine:1.00.0.217
     restart: always
     privileged: true
     network_mode: service:traffic_engine_2

--- a/docker-compose/cpdp-b2b/tests/go.mod
+++ b/docker-compose/cpdp-b2b/tests/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/open-traffic-generator/otg-examples v0.0.0-20220802143508-a81f2c7fbcf2
-	github.com/open-traffic-generator/snappi/gosnappi v0.8.5
+	github.com/open-traffic-generator/snappi/gosnappi v0.9.3
 )
 
 require (
@@ -25,8 +25,8 @@ require (
 	golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211129164237-f09f9a12af12 // indirect
-	google.golang.org/grpc v1.48.0 // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
+	google.golang.org/grpc v1.49.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/docker-compose/cpdp-b2b/tests/go.sum
+++ b/docker-compose/cpdp-b2b/tests/go.sum
@@ -76,8 +76,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/open-traffic-generator/otg-examples v0.0.0-20220802143508-a81f2c7fbcf2 h1:gGgzmkHufkcaEeavz5gyMqhw4OY1Q+d/NjKqL60oAvc=
 github.com/open-traffic-generator/otg-examples v0.0.0-20220802143508-a81f2c7fbcf2/go.mod h1:7ZpfxUaPgwXgwmExZZgkP57ZFa/CkrDu2cxRh0ffasI=
-github.com/open-traffic-generator/snappi/gosnappi v0.8.5 h1:UIA4EpMwvDJYZ4htsnwUU+JB83GRZXrexSv9+S9KZh8=
-github.com/open-traffic-generator/snappi/gosnappi v0.8.5/go.mod h1:8teR2eonSEJTr/Y1B125KN23RTmGh6ybgURTt28IlI0=
+github.com/open-traffic-generator/snappi/gosnappi v0.9.3 h1:J9yq5G/AkI5TyHFmqaftjv580RGTFqfj5e+RFZdvesc=
+github.com/open-traffic-generator/snappi/gosnappi v0.9.3/go.mod h1:elsB41LK8QapLrlfZJucYrQhxEw3ylGo3JgKo8kerZI=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20220131173555-39aa74195f0d h1:ctQhZfeVyJTgTt8DW13WlClRv56X18eoGVLrwX1KaZg=
@@ -191,8 +191,8 @@ google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA5
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.37.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.48.0 h1:rQOsyJ/8+ufEDJd/Gdsz7HG220Mh9HAhFHRGnIjda0w=
-google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.49.0 h1:WTLtQzmQori5FUH25Pq4WT22oCsv8USpQ+F6rqtsmxw=
+google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -207,8 +207,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Use of docker hub was obsoleted in favor of ghrc.com starting with Ixia-c [Release v0.0.1-3113](https://github.com/open-traffic-generator/ixia-c/releases/tag/v0.0.1-3113)