### PR TITLE
Testdrive fixes

### DIFF
--- a/clab/ixia-c-te-frr/README.md
+++ b/clab/ixia-c-te-frr/README.md
@@ -18,7 +18,7 @@ Follow this sections for a quick version of how to run the lab using `make`. Thi
 1. Clone this repository
 
     ```Shell
-    git clone https://github.com/open-traffic-generator/otg-examples.git
+    git clone --recursive https://github.com/open-traffic-generator/otg-examples.git
     cd otg-examples/clab/ixia-c-te-frr
     ```
 

--- a/clab/rtbh/README.md
+++ b/clab/rtbh/README.md
@@ -11,7 +11,7 @@ Read a [blog post](https://blogs.keysight.com/blogs/tech/traf-gen.entry.html/202
 ## Prerequisites
 
 * Linux host or VM with sudo permissions and Docker support. See [some ready-to-use options below](#options-for-linux-vm-deployment-for-containerlab)
-* `git` - how to install depends on your Linux distro.
+* `git` and `build-essential` packages - how to install depends on your Linux distribution
 * [Docker](https://docs.docker.com/engine/install/)
 * [Containerlab](https://containerlab.dev/install/)
 * Access to the Linux host from your computer over TCP ports 22 (SSH), 8008 (DDoS Protect Dashboard) and 8080 (Graphite topology visualization)
@@ -107,7 +107,7 @@ sudo -E containerlab destroy -t topo.yml
     --tags=otg-demo
 
     gcloud compute ssh otg-demo
-    sudo apt update && sudo apt install docker.io -y
+    sudo apt update && sudo apt install docker.io build-essential -y
     bash -c "$(curl -sL https://get.containerlab.dev)"
     ```
 

--- a/clab/rtbh/README.md
+++ b/clab/rtbh/README.md
@@ -21,7 +21,7 @@ Read a [blog post](https://blogs.keysight.com/blogs/tech/traf-gen.entry.html/202
 1. Clone this repository to the Linux host where you want to run the lab. Do this only once.
 
     ```Shell
-    git clone --single-branch https://github.com/open-traffic-generator/otg-examples.git
+    git clone --recursive --single-branch https://github.com/open-traffic-generator/otg-examples.git
     ```
 
 2. Navigate to the lab folder

--- a/docker-compose/b2b-3pair/Makefile
+++ b/docker-compose/b2b-3pair/Makefile
@@ -39,10 +39,10 @@ install-clean:
 pull: pull-public pull-private
 
 pull-public:
-	sudo docker-compose pull traffic_engine_1
+	sudo -E docker-compose pull traffic_engine_1
 	
 pull-private:
-	sudo docker-compose pull controller
+	sudo -E docker-compose pull controller
 
 ###############################
 # Deploy lab

--- a/docker-compose/b2b-3pair/Makefile
+++ b/docker-compose/b2b-3pair/Makefile
@@ -39,10 +39,10 @@ install-clean:
 pull: pull-public pull-private
 
 pull-public:
-	docker-compose pull traffic_engine_1
+	sudo docker-compose pull traffic_engine_1
 	
 pull-private:
-	docker-compose pull controller
+	sudo docker-compose pull controller
 
 ###############################
 # Deploy lab
@@ -90,7 +90,7 @@ deploy-lab:
 deploy: deploy-net deploy-lab 
 
 lab-clean:
-	docker-compose down
+	sudo docker-compose down
 
 network-clean: veth0-clean veth2-clean veth4-clean
 veth0-clean:

--- a/docker-compose/b2b-3pair/Makefile
+++ b/docker-compose/b2b-3pair/Makefile
@@ -23,7 +23,7 @@ install-docker-compose: /usr/local/bin/docker-compose
 	
 install-otgen: /usr/local/bin/otgen
 /usr/local/bin/otgen:
-	curl -L "https://github.com/open-traffic-generator/otgen/releases/download/v0.3.0/otgen_0.3.0_$$(uname -s)_$$(uname -m).tar.gz" | tar xzv otgen
+	curl -L "https://github.com/open-traffic-generator/otgen/releases/download/v0.4.0/otgen_0.4.0_$$(uname -s)_$$(uname -m).tar.gz" | tar xzv otgen
 	sudo mv otgen /usr/local/bin/otgen
 	sudo chmod +x /usr/local/bin/otgen
 
@@ -112,13 +112,13 @@ veth4-clean:
 run: otgen-run otgen-run-display-table-port otgen-run-display-table-port otgen-run-display-table-flow-bytes
 
 otgen-run:
-	otgen run -k -f otg.3pairs.yml
+	otgen run -a https://localhost:8443 -k -f otg.3pairs.yml
 
 otgen-run-display-table-port:
-	otgen run -k -f otg.3pairs.yml | otgen transform -m port | otgen display -m table
+	otgen run -a https://localhost:8443 -k -f otg.3pairs.yml | otgen transform -m port | otgen display -m table
 
 otgen-run-display-table-flow:
-	otgen run -k -f otg.3pairs.yml | otgen transform -m flow | otgen display -m table
+	otgen run -a https://localhost:8443 -k -f otg.3pairs.yml | otgen transform -m flow | otgen display -m table
 
 otgen-run-display-table-flow-bytes:
-	otgen run -k -f otg.3pairs.yml -m flow | otgen transform -m flow -c bytes | otgen display -m table
+	otgen run -a https://localhost:8443 -k -f otg.3pairs.yml -m flow | otgen transform -m flow -c bytes | otgen display -m table

--- a/docker-compose/b2b-3pair/README.md
+++ b/docker-compose/b2b-3pair/README.md
@@ -73,7 +73,7 @@ This lab is an extension of [Ixia-c back-to-back](README.md) traffic engine setu
 
     ```Shell
     cd otg-examples/docker-compose/b2b-3pair
-    sudo docker-compose up -d 
+    sudo -E docker-compose up -d 
     sudo ip link set veth0 mtu 9500
     sudo ip link set veth1 mtu 9500
     sudo ip link set veth2 mtu 9500

--- a/docker-compose/b2b-3pair/README.md
+++ b/docker-compose/b2b-3pair/README.md
@@ -106,31 +106,31 @@ This lab is an extension of [Ixia-c back-to-back](README.md) traffic engine setu
 1. Start with using `otgen` to request Ixia-c to run traffic flows defined in `otg.3pairs.yml`. If successful, the result will come as OTG port metrics in JSON format
 
     ```Shell
-    otgen run -k -f otg.3pairs.yml
+    otgen run -a https://localhost:8443 -k -f otg.3pairs.yml
     ```
 
 2. You can now repeat this exercise, but transform output to a table
 
     ```Shell
-    otgen run -k -f otg.3pairs.yml | otgen transform -m port | otgen display -m table
+    otgen run -a https://localhost:8443 -k -f otg.3pairs.yml | otgen transform -m port | otgen display -m table
     ```
 
 3. The same, but with flow metrics
 
     ```Shell
-    otgen run -k -f otg.3pairs.yml -m flow | otgen transform -m flow | otgen display -m table
+    otgen run -a https://localhost:8443 -k -f otg.3pairs.yml -m flow | otgen transform -m flow | otgen display -m table
     ```
 
 4. The same, but with byte instead of frame count (only receive stats are reported)
 
     ```Shell
-    otgen run -k -f otg.3pairs.yml -m flow | otgen transform -m flow -c bytes | otgen display -m table
+    otgen run -a https://localhost:8443 -k -f otg.3pairs.yml -m flow | otgen transform -m flow -c bytes | otgen display -m table
     ```
 
 5. Now report packet per second rate, as a line chart (end with `Ctrl-c`)
 
     ```Shell
-    otgen run -k -f otg.3pairs.yml -m flow | otgen transform -m flow -c pps | otgen display -m chart
+    otgen run -a https://localhost:8443 -k -f otg.3pairs.yml -m flow | otgen transform -m flow -c pps | otgen display -m chart
     ```
 
 ## Destroy the lab

--- a/docker-compose/b2b-3pair/README.md
+++ b/docker-compose/b2b-3pair/README.md
@@ -42,7 +42,7 @@ This lab is an extension of [Ixia-c back-to-back](README.md) traffic engine setu
 4. Clone this repository
 
     ```Shell
-    git clone https://github.com/open-traffic-generator/otg-examples.git
+    git clone --recursive https://github.com/open-traffic-generator/otg-examples.git
     ```
 
 ## Deploy lab

--- a/docker-compose/b2b-3pair/compose.yml
+++ b/docker-compose/b2b-3pair/compose.yml
@@ -1,7 +1,7 @@
 services:
   controller:
-    image: ghcr.io/open-traffic-generator/licensed/ixia-c-controller:0.0.1-3423
-    command: --accept-eula --http-port 443
+    image: ghcr.io/open-traffic-generator/licensed/ixia-c-controller:0.0.1-3698
+    command: --accept-eula --http-port 8443
     network_mode: "host"
     restart: always
   traffic_engine_1:

--- a/docker-compose/b2b/Makefile
+++ b/docker-compose/b2b/Makefile
@@ -66,7 +66,7 @@ deploy-lab:
 	sudo docker-compose -f ixia-c-b2b.yml up -d 
 
 remove-lab:
-	docker-compose -f ixia-c-b2b.yml down
+	sudo docker-compose -f ixia-c-b2b.yml down
 
 ###############################
 # Run tests

--- a/docker-compose/b2b/README.md
+++ b/docker-compose/b2b/README.md
@@ -39,6 +39,13 @@ This is a basic lab where [Ixia-c](https://github.com/open-traffic-generator/ixi
     fi
     ```
 
+4. Clone this repository (optional, only needed to use `make all` to run all the steps automatically)
+
+    ```Shell
+    git clone --recursive https://github.com/open-traffic-generator/otg-examples.git
+    cd otg-examples/docker-compose/b2b
+    ```
+
 ## Deploy Ixia-c lab
 
 1. Create veth pair `veth0 - veth1`

--- a/docker-compose/cpdp-b2b/Makefile
+++ b/docker-compose/cpdp-b2b/Makefile
@@ -32,10 +32,10 @@ install-clean:
 pull: pull-public pull-private
 
 pull-public:
-	sudo docker-compose pull traffic_engine_1
+	sudo -E docker-compose pull traffic_engine_1
 	
 pull-private:
-	sudo docker-compose pull controller protocol_engine_1
+	sudo -E docker-compose pull controller protocol_engine_1
 
 ###############################
 # Deploy lab

--- a/docker-compose/cpdp-b2b/Makefile
+++ b/docker-compose/cpdp-b2b/Makefile
@@ -32,10 +32,10 @@ install-clean:
 pull: pull-public pull-private
 
 pull-public:
-	docker-compose pull traffic_engine_1
+	sudo docker-compose pull traffic_engine_1
 	
 pull-private:
-	docker-compose pull controller protocol_engine_1
+	sudo docker-compose pull controller protocol_engine_1
 
 ###############################
 # Deploy lab
@@ -51,7 +51,7 @@ deploy-net:
 	sudo ../../utils/connect_containers_veth.sh cpdp-b2b_traffic_engine_1_1 cpdp-b2b_traffic_engine_2_1 veth0 veth1
 
 remove-lab:
-	docker-compose down
+	sudo docker-compose down
 
 ###############################
 # Run tests

--- a/docker-compose/cpdp-b2b/README.md
+++ b/docker-compose/cpdp-b2b/README.md
@@ -36,7 +36,7 @@ This is an extended version of a basic [Ixia-c back-2-back lab](../b2b/README.md
 1. Clone this repository
 
     ```Shell
-    git clone https://github.com/open-traffic-generator/otg-examples.git
+    git clone --recursive https://github.com/open-traffic-generator/otg-examples.git
     ```
 
 ## Deploy Ixia-c lab

--- a/docker-compose/cpdp-b2b/README.md
+++ b/docker-compose/cpdp-b2b/README.md
@@ -45,7 +45,7 @@ This is an extended version of a basic [Ixia-c back-2-back lab](../b2b/README.md
 
     ```Shell
     cd otg-examples/docker-compose/cpdp-b2b
-    sudo docker-compose up -d 
+    sudo -E docker-compose up -d 
     sudo docker ps
     ```
 

--- a/docker-compose/cpdp-frr/Makefile
+++ b/docker-compose/cpdp-frr/Makefile
@@ -47,11 +47,11 @@ install-clean:
 pull: pull-private
 
 pull-public:
-	docker-compose pull traffic_engine_1
-	docker-compose pull frr
+	sudo docker-compose pull traffic_engine_1
+	sudo docker-compose pull frr
 	
 pull-private:
-	docker-compose pull controller protocol_engine_1
+	sudo docker-compose pull controller protocol_engine_1
 
 ###############################
 # Deploy lab
@@ -71,7 +71,7 @@ deploy-clab:
 	sudo containerlab deploy --reconfigure
 
 remove-lab:
-	docker-compose down
+	sudo docker-compose down
 
 remove-clab:
 	sudo containerlab destroy --cleanup

--- a/docker-compose/cpdp-frr/Makefile
+++ b/docker-compose/cpdp-frr/Makefile
@@ -47,11 +47,11 @@ install-clean:
 pull: pull-private
 
 pull-public:
-	sudo docker-compose pull traffic_engine_1
-	sudo docker-compose pull frr
+	sudo -E docker-compose pull traffic_engine_1
+	sudo -E docker-compose pull frr
 	
 pull-private:
-	sudo docker-compose pull controller protocol_engine_1
+	sudo -E docker-compose pull controller protocol_engine_1
 
 ###############################
 # Deploy lab

--- a/docker-compose/cpdp-frr/README.md
+++ b/docker-compose/cpdp-frr/README.md
@@ -72,7 +72,7 @@ To request KENG to use ARP to determine destination MAC address for a flow `f1`,
 1. Clone this repository
 
     ```Shell
-    git clone https://github.com/open-traffic-generator/otg-examples.git
+    git clone --recursive https://github.com/open-traffic-generator/otg-examples.git
     cd otg-examples/docker-compose/cpdp-frr
     ```
 
@@ -139,7 +139,7 @@ To request KENG to use ARP to determine destination MAC address for a flow `f1`,
 5. Clone this repository
 
     ```Shell
-    git clone https://github.com/open-traffic-generator/otg-examples.git
+    git clone --recursive https://github.com/open-traffic-generator/otg-examples.git
     ```
 
 ## Docker Compose option to deploy the lab


### PR DESCRIPTION
Fixes for cloud test drive:

- `sudo` -related fixes for `make all` to run on VMs when the user is not part of the docker group
- `git clone --recursive` to clone submodules #32 