### PR TITLE
Update compose.argpin.yml

### DIFF
--- a/docker-compose/b2b-pinning/compose.argpin.yml
+++ b/docker-compose/b2b-pinning/compose.argpin.yml
@@ -13,7 +13,7 @@ services:
     environment:
     - OPT_LISTEN_PORT=5555
     - ARG_IFACE_LIST=virtual@af_packet,veth0
-    - ARG_CORE_LIST=2,3,4
+    - ARG_CORE_LIST=2 3 4
     - OPT_NO_HUGEPAGES=Yes
   traffic_engine_2:
     image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.24
@@ -24,5 +24,5 @@ services:
     environment:
     - OPT_LISTEN_PORT=5556
     - ARG_IFACE_LIST=virtual@af_packet,veth1
-    - ARG_CORE_LIST=2,5,6
+    - ARG_CORE_LIST=2 5 6
     - OPT_NO_HUGEPAGES=Yes


### PR DESCRIPTION
@bortok 
The traffic engine expects a space separated list of core ids for the ARG_CORE_LIST parameter, not a comma separated one.