### PR TITLE
Not able to collect docker logs for OTG-HW 

### DIFF
--- a/utils/collect-ixia-c-hw-logs.sh
+++ b/utils/collect-ixia-c-hw-logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONTAINERS=$(docker ps --filter "name=ixia-c" --format "{{.Names}}")
+CONTAINERS=$(docker ps --filter "name=ixia-c|ixhw" --format "{{.Names}}")
 NOW="logs-"$(date +"%Y-%m-%d_%H%M%S")
 mkdir -p $NOW
 for CONTAINER in $CONTAINERS


### PR DESCRIPTION
This is continuation of this PR  https://github.com/open-traffic-generator/fp-testbed-nokia/pull/17 though I feel that fix will regress current intention of this script which is to pull logs for all three dockes.
So, I am proposing this fix.