### PR TITLE
Fix issues with FRR BGP test including flaps . 

### DIFF
--- a/docker-compose/cpdp-frr/Makefile
+++ b/docker-compose/cpdp-frr/Makefile
@@ -64,7 +64,6 @@ deploy-lab:
 deploy-net:
 	sudo /bin/bash ../../utils/connect_containers_veth.sh cpdp-frr_traffic_engine_1_1 cpdp-frr_frr_1 veth0 veth1
 	sudo /bin/bash ../../utils/connect_containers_veth.sh cpdp-frr_traffic_engine_2_1 cpdp-frr_frr_1 veth2 veth3
-	sleep 10 
 
 deploy-clab:
 	sudo -E containerlab deploy --reconfigure
@@ -88,7 +87,7 @@ otg-set-config:
 	@echo "############################################"
 	@echo "# Apply OTG configuration"
 	@echo
-	sleep 5 # pause for keng-controller to detect newly created interfaces
+	sleep 10 # pause for containers to get ready
 	curl -sk "$(OTG_HOST)/config" \
 		-H "Content-Type: application/json" \
 		-d @otg.json | tee curl.out
@@ -121,7 +120,7 @@ otg-fetch-bgp:
 	@echo "############################################"
 	@echo "# Fetch BGP metrics"
 	@echo
-	sleep 5 # pause for BGP to converge
+	sleep 10 # pause for BGP to converge
 	curl -sk "$(OTG_HOST)/monitor/metrics" \
 		-X POST \
 		-H  'Content-Type: application/json' \
@@ -129,10 +128,21 @@ otg-fetch-bgp:
 	@echo
 	cat curl.out | jq -e "if (.bgpv4_metrics | length) == 2 and \
 		.bgpv4_metrics[0].session_state == \"up\" and \
-		.bgpv4_metrics[0].routes_received == \"2\" and \
+		.bgpv4_metrics[0].routes_received == \"1\" and \
 		.bgpv4_metrics[1].session_state == \"up\" and \
-		.bgpv4_metrics[1].routes_received == \"2\" \
+		.bgpv4_metrics[1].routes_received == \"1\" \
 		then true else false end"
+
+	sleep 4 #Next fetch the routes learned.
+	#Note: By default FRR seems to be sending back same prefix which it learned
+	#which it should not. Added solo mode in FRR config to work around this.
+	@echo "# Fetch BGP prefixes"
+	@echo
+	curl -sk "${OTG_HOST}/monitor/states" \
+		-X POST \
+		-H  'Content-Type: application/json' \
+		-d '{ "choice": "bgp_prefixes" }'
+
 
 otg-trasmit:
 	@echo "############################################"

--- a/docker-compose/cpdp-frr/compose.yml
+++ b/docker-compose/cpdp-frr/compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       - INTF_LIST=veth2
   frr:
-    image: quay.io/frrouting/frr:9.1.0
+    image: quay.io/frrouting/frr:10.3.0
     cap_add:
       - NET_ADMIN
       - NET_RAW

--- a/docker-compose/cpdp-frr/frr/frr.conf
+++ b/docker-compose/cpdp-frr/frr/frr.conf
@@ -1,31 +1,51 @@
 !
-frr version 8.2.2_git
 frr defaults traditional
 hostname frr
 no ipv6 forwarding
 log stdout
 !
 interface veth1
- ip address 192.0.2.2/30
+ ip address 192.0.2.2/24
 exit
 !
 interface veth3
- ip address 192.0.2.6/30
+ ip address 192.0.3.2/24
 exit
 !
 interface lo
  ip address 3.3.3.3/32
 exit
 !
+#Without the route-map forcing FRR to add the NHOP, FRR
+#was forwarding Updates without NHOP, causing session flap.
+#Root cause of this is not known. Please log an Issue in ixia-c 
+#repo if change in FRR config/specific behaviour on ixia-c side 
+#is known to get FRR to include NHOP without needing this.
+route-map SETNH permit 10
+ set ip next-hop 192.0.2.2
+exit
+!
+route-map SETNH2 permit 10
+ set ip next-hop 192.0.3.2
+exit
+!
 router bgp 3333
  bgp router-id 3.3.3.3
  no bgp ebgp-requires-policy
  neighbor 192.0.2.1 remote-as 1111
+ neighbor 192.0.3.1 remote-as 2222
+ #Somehow without this it sends back routes to originating port!
  neighbor 192.0.2.1 solo
- neighbor 192.0.2.1 next-hop-self
- neighbor 192.0.2.5 remote-as 2222
- neighbor 192.0.2.5 solo
- neighbor 192.0.2.5 next-hop-self
+ neighbor 192.0.3.1 solo
+ !
+ address-family ipv4 unicast
+  #This should have worked but need the route-map 
+  #to force FRR to include NHOP. Refer above.
+  #neighbor 192.0.2.1 next-hop-self
+  neighbor 192.0.2.1 route-map SETNH out
+  neighbor 192.0.3.1 route-map SETNH2 out
+ exit-address-family
+
 exit
 !
 end

--- a/docker-compose/cpdp-frr/otg.json
+++ b/docker-compose/cpdp-frr/otg.json
@@ -21,7 +21,7 @@
             {
               "gateway":  "192.0.2.2",
               "address":  "192.0.2.1",
-              "prefix":  30,
+              "prefix":  24,
               "name":  "otg1.eth[0].ipv4[0]"
             }
           ],
@@ -31,7 +31,7 @@
         }
       ],
       "bgp":  {
-        "router_id":  "1.1.1.1",
+        "router_id":  "192.0.2.1",
         "ipv4_interfaces":  [
           {
             "ipv4_name":  "otg1.eth[0].ipv4[0]",
@@ -51,16 +51,12 @@
                         "step":  1
                       }
                     ],
-                    "next_hop_mode":  "manual",
-                    "next_hop_address_type":  "ipv4",
-                    "next_hop_ipv4_address":  "192.0.2.1",
                     "name":  "otg1.bgp4.peer[0].rr4"
                   }
                 ],
                 "name":  "otg1.bgp4.peer[0]",
                 "learned_information_filter": {
-                  "unicast_ipv4_prefix": true,
-                  "unicast_ipv6_prefix": true
+                  "unicast_ipv4_prefix": true
                 }
               }
             ]
@@ -78,9 +74,9 @@
           },
           "ipv4_addresses":  [
             {
-              "gateway":  "192.0.2.6",
-              "address":  "192.0.2.5",
-              "prefix":  30,
+              "gateway":  "192.0.3.2",
+              "address":  "192.0.3.1",
+              "prefix":  24,
               "name":  "otg2.eth[0].ipv4[0]"
             }
           ],
@@ -90,13 +86,13 @@
         }
       ],
       "bgp":  {
-        "router_id":  "2.2.2.2",
+        "router_id":  "192.0.3.2",
         "ipv4_interfaces":  [
           {
             "ipv4_name":  "otg2.eth[0].ipv4[0]",
             "peers":  [
               {
-                "peer_address":  "192.0.2.6",
+                "peer_address":  "192.0.3.2",
                 "as_type":  "ebgp",
                 "as_number":  2222,
                 "as_number_width":  "four",
@@ -110,16 +106,12 @@
                         "step":  1
                       }
                     ],
-                    "next_hop_mode":  "manual",
-                    "next_hop_address_type":  "ipv4",
-                    "next_hop_ipv4_address":  "192.0.2.5",
                     "name":  "otg2.bgp4.peer[0].rr4"
                   }
                 ],
                 "name":  "otg2.bgp4.peer[0]",
                 "learned_information_filter": {
-                  "unicast_ipv4_prefix": true,
-                  "unicast_ipv6_prefix": true
+                  "unicast_ipv4_prefix": true
                 }
               }
             ]


### PR DESCRIPTION
Upgraded FRR to 10.3.0 from 9.1.0 + saner intf addresses/masks + changed FRR config to ensure Updates from FRR have NHOP + solo option workaround to avoid FRR reflecting back routes + added get_states in Makefile

For final closure of 
https://github.com/open-traffic-generator/otg-examples/issues/79
https://github.com/open-traffic-generator/ixia-c/issues/209
Also allows proper run of 
https://github.com/open-traffic-generator/otg-examples/issues/77